### PR TITLE
fix for nav arrows

### DIFF
--- a/extensions/navigation/deck.navigation.css
+++ b/extensions/navigation/deck.navigation.css
@@ -29,7 +29,7 @@
 }
 
 .deck-container:hover .deck-prev-link, .deck-container:hover .deck-next-link {
-  display: block;
+  display: block !important;
 }
 .deck-container:hover .deck-prev-link.deck-nav-disabled, .touch .deck-container:hover .deck-prev-link, .deck-container:hover .deck-next-link.deck-nav-disabled, .touch .deck-container:hover .deck-next-link {
   display: none;


### PR DESCRIPTION
There is an issue in some browser versions with the nav arrows not displaying. This is because of complicated conflicts in the CSS styles applied. Adding !important here forces the arrows to appear.